### PR TITLE
bump golang image versions to 1.13

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -22,7 +22,7 @@ pipeline {
     stage('Vendor Dependencies') {
       agent {
         docker {
-          image 'vaporio/golang:1.11'
+          image 'vaporio/golang:1.13'
           reuseNode true
         }
       }
@@ -49,7 +49,7 @@ pipeline {
     stage('Lint') {
       agent {
         docker {
-          image 'vaporio/golang:1.11'
+          image 'vaporio/golang:1.13'
           reuseNode true
         }
       }
@@ -77,7 +77,7 @@ pipeline {
     stage('Build Release Artifacts') {
       agent {
         docker {
-          image 'vaporio/golang:1.11'
+          image 'vaporio/golang:1.13'
           reuseNode true
         }
       }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder Image
-FROM vaporio/golang:1.11 as builder
+FROM vaporio/golang:1.13 as builder
 WORKDIR /go/src/github.com/vapor-ware/sandbox-plugin
 COPY . .
 


### PR DESCRIPTION
This PR:
- bumps the version of the `vaporio/golang` image used in CI and the Dockerfile from 1.11 (deprecated) to 1.13

fixes #2 

Note that this only bumps the docker version. There may need to be additional CI config updates to bring CI up to date with latest changes.