### PR TITLE
updates to CI

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,8 +2,6 @@
 project_name: sandbox-plugin
 before:
   hooks:
-    - go clean -v
-    - rm -rf dist
     - go mod download
 builds:
   - env:
@@ -13,7 +11,7 @@ builds:
       - -X github.com/vapor-ware/synse-sdk/sdk.BuildDate={{ .Date }}
       - -X github.com/vapor-ware/synse-sdk/sdk.GitCommit={{ .ShortCommit }}
       - -X github.com/vapor-ware/synse-sdk/sdk.GitTag={{ .Tag }}
-      - -X github.com/vapor-ware/synse-sdk/sdk.GoVersion={{ .Env.GOVERSION }}
+      - -X github.com/vapor-ware/synse-sdk/sdk.GoVersion={{ .Env.GOLANG_VERSION }}
       - -X github.com/vapor-ware/synse-sdk/sdk.PluginVersion={{ .Version }}
     goos:
       - linux

--- a/.jenkins
+++ b/.jenkins
@@ -2,11 +2,12 @@
 
 pipeline {
 
-  agent any
+  agent {
+    label 'golang-alpha'
+  }
 
   environment {
     IMAGE_NAME = 'vaporio/sandbox-plugin'
-    GOVERSION = '1.12'
   }
 
   stages {
@@ -16,33 +17,22 @@ pipeline {
       }
     }
 
-    stage('Lint') {
-      steps {
-        script {
-          docker.image('vaporio/jenkins-agent-golang:latest').inside() {
-            // All the deps to build this project are provided by the runtime container
-            // Skip the configuration management and let the pipeline assets do that for you.
-            sh 'golint -set_exit_status ./pkg/...'
+    stage('Checks') {
+      parallel {
+
+        stage('Lint') {
+          steps {
+            container('golang') {
+              sh 'golint -set_exit_status ./pkg/...'
+            }
           }
         }
-      }
-    }
 
-    stage('Snapshot Build') {
-      steps {
-        script {
-          /* This replicates some of what the docker agent would do if this were
-             running natively in kube. We would version these same params in
-             the agent config. This is a bit of a phaux pre-dep test to getting
-             agents running in kube. the containers are acting just like the
-             host agent would, but in spurts.
-
-             Note: the importance of the --group-add docker in the parameters.
-             Without it, docker in agent is mysteriously permission
-             locked despite having a GID present in the container.
-          */
-          docker.image('vaporio/jenkins-agent-golang:latest').inside('-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add docker') {
-            sh '&& goreleaser release --snapshot --skip-publish --rm-dist'
+        stage('Snapshot Build') {
+          steps {
+            container('golang') {
+              sh 'goreleaser release --debug --snapshot --skip-publish --rm-dist'
+            }
           }
         }
       }
@@ -53,26 +43,25 @@ pipeline {
         branch 'master'
       }
       steps {
-        withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
-          sh 'docker push ${IMAGE_NAME}:latest'
+        container('golang') {
+          withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
+            sh 'docker push ${IMAGE_NAME}:latest'
+          }
         }
       }
     }
 
     stage('Tagged Release') {
       when {
-        // example matches: 1.2.3, 1.2.3-dev
-        tag pattern: '(0|[1-9]*)\\.(0|[1-9]*)\\.(0|[1-9]*)(-(\\S*))?$', comparator: "REGEXP"
+        buildingTag()
       }
       environment {
         GITHUB_TOKEN = credentials('vio-bot-gh-token')
       }
       steps {
-        script {
-          docker.image('vaporio/jenkins-agent-golang:latest').inside('-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -e GITHUB_TOKEN=$GITHUB_TOKEN --group-add docker') {
-            withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
-              sh 'goreleaser release --rm-dist'
-            }
+        container('golang') {
+          withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
+            sh 'goreleaser release --debug --rm-dist'
           }
         }
       }


### PR DESCRIPTION
This PR:
- updates CI to use the latest patterns


I added the linting and snapshot build to a `parallel` block, but it doesn't look like they executed in parallel -- @lazypower I'm unsure if I just declared it incorrectly, or if its not possible to do w/ the new setup.

I also noticed that it spins up a new pod for stages which will be skipped, so skipped stages have to wait until the pod is ready in order to be skipped. Not sure if there is something I should be doing in config to avoid this, or if this is a known thing and is on the plate of future improvements